### PR TITLE
Implement basic 2FA via TOTP

### DIFF
--- a/Cryptig.Core/Cryptig.Core.csproj
+++ b/Cryptig.Core/Cryptig.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
+    <PackageReference Include="Otp.NET" Version="1.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
   </ItemGroup>

--- a/Cryptig.Core/TwoFactorAuth.cs
+++ b/Cryptig.Core/TwoFactorAuth.cs
@@ -1,0 +1,26 @@
+using OtpNet;
+using System;
+
+namespace Cryptig.Core
+{
+    public static class TwoFactorAuth
+    {
+        public static string GenerateSecret()
+        {
+            var bytes = KeyGeneration.GenerateRandomKey(20);
+            return Base32Encoding.ToString(bytes);
+        }
+
+        public static string GenerateCode(string secret)
+        {
+            var totp = new Totp(Base32Encoding.ToBytes(secret));
+            return totp.ComputeTotp();
+        }
+
+        public static bool VerifyCode(string secret, string code)
+        {
+            var totp = new Totp(Base32Encoding.ToBytes(secret));
+            return totp.VerifyTotp(code, out long _);
+        }
+    }
+}

--- a/Cryptig.Core/VaultData.cs
+++ b/Cryptig.Core/VaultData.cs
@@ -4,6 +4,12 @@ namespace Cryptig.Core
 {
     public class VaultData
     {
+        /// <summary>
+        /// Base32 encoded secret used for generating TOTP codes. If null or empty,
+        /// two-factor authentication is considered disabled.
+        /// </summary>
+        public string? TwoFactorSecret { get; set; }
+
         public List<VaultEntry> Entries { get; set; } = new();
     }
 }

--- a/Cryptig/Cryptig.csproj
+++ b/Cryptig/Cryptig.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+    <PackageReference Include="QRCoder" Version="1.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Cryptig/Form1.cs
+++ b/Cryptig/Form1.cs
@@ -71,11 +71,13 @@ namespace Cryptig
             ToolStripMenuItem lockItem = new ToolStripMenuItem("Lock Vault");
             ToolStripMenuItem createFVItem = new ToolStripMenuItem("Create File Vault");
             ToolStripMenuItem openFVItem = new ToolStripMenuItem("Open File Vault");
+            ToolStripMenuItem twoFactorItem = new ToolStripMenuItem("Two-Factor Setup");
             importItem.Click += ImportVault_Click;
             exportItem.Click += ExportVault_Click;
             lockItem.Click += (s, e) => LockVault();
             createFVItem.Click += CreateFileVault_Click;
             openFVItem.Click += OpenFileVault_Click;
+            twoFactorItem.Click += TwoFactorItem_Click;
 
             menuStrip.Dock = DockStyle.Top;
             fileMenu.DropDownItems.Add(importItem);
@@ -84,6 +86,7 @@ namespace Cryptig
             fileMenu.DropDownItems.Add(new ToolStripSeparator());
             fileMenu.DropDownItems.Add(createFVItem);
             fileMenu.DropDownItems.Add(openFVItem);
+            fileMenu.DropDownItems.Add(twoFactorItem);
             menuStrip.Items.Add(fileMenu);
 
             ToolStripMenuItem helpMenu = new ToolStripMenuItem("Help");
@@ -673,6 +676,32 @@ namespace Cryptig
                 }
             }
             Show();
+        }
+
+        private void TwoFactorItem_Click(object? sender, EventArgs e)
+        {
+            if (_vault == null) return;
+
+            if (string.IsNullOrEmpty(_vault.Data.TwoFactorSecret))
+            {
+                string secret = TwoFactorAuth.GenerateSecret();
+                using var setup = new TwoFactorSetupForm(secret);
+                if (setup.ShowDialog(this) == DialogResult.OK && setup.Confirmed)
+                {
+                    _vault.Data.TwoFactorSecret = secret;
+                    _vault.Save();
+                    MessageBox.Show("Two-factor authentication enabled.");
+                }
+            }
+            else
+            {
+                if (MessageBox.Show("Disable two-factor authentication?", "Confirm", MessageBoxButtons.YesNo) == DialogResult.Yes)
+                {
+                    _vault.Data.TwoFactorSecret = null;
+                    _vault.Save();
+                    MessageBox.Show("Two-factor authentication disabled.");
+                }
+            }
         }
 
         private void Form1_KeyDown(object sender, KeyEventArgs e)

--- a/Cryptig/Program.cs
+++ b/Cryptig/Program.cs
@@ -32,6 +32,17 @@ namespace Cryptig
                     if (vault == null)
                         throw new Exception("Vault is null.");
 
+                    if (!string.IsNullOrEmpty(vault.Data.TwoFactorSecret))
+                    {
+                        using var tf = new TwoFactorForm();
+                        if (tf.ShowDialog() != DialogResult.OK ||
+                            !TwoFactorAuth.VerifyCode(vault.Data.TwoFactorSecret, tf.EnteredCode))
+                        {
+                            MessageBox.Show("Invalid authentication code.");
+                            continue;
+                        }
+                    }
+
                     Application.Run(new Form1(vault, login.EnteredUsername, login.EnteredPassword));
                     break;
                 }

--- a/Cryptig/TwoFactorForm.cs
+++ b/Cryptig/TwoFactorForm.cs
@@ -1,0 +1,30 @@
+using System.Windows.Forms;
+
+namespace Cryptig
+{
+    public class TwoFactorForm : Form
+    {
+        private TextBox txtCode;
+        private Button btnVerify;
+        public string EnteredCode { get; private set; } = string.Empty;
+
+        public TwoFactorForm()
+        {
+            Text = "Two-Factor Authentication";
+            Width = 300;
+            Height = 160;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+
+            Label lbl = new Label { Text = "Authentication Code", Top = 20, Left = 20, Width = 240 };
+            txtCode = new TextBox { Top = lbl.Bottom + 2, Left = 20, Width = 240 };
+            btnVerify = new Button { Text = "Verify", Top = txtCode.Bottom + 10, Left = 20, Width = 240 };
+            btnVerify.Click += (s, e) => { EnteredCode = txtCode.Text.Trim(); DialogResult = DialogResult.OK; Close(); };
+
+            Controls.AddRange(new Control[] { lbl, txtCode, btnVerify });
+            AcceptButton = btnVerify;
+        }
+    }
+}

--- a/Cryptig/TwoFactorSetupForm.cs
+++ b/Cryptig/TwoFactorSetupForm.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using Cryptig.Core;
+using QRCoder;
+
+namespace Cryptig
+{
+    public class TwoFactorSetupForm : Form
+    {
+        private readonly string _secret;
+        private readonly TextBox _txtCode;
+        public bool Confirmed { get; private set; }
+        public string Secret => _secret;
+
+        public TwoFactorSetupForm(string secret)
+        {
+            _secret = secret;
+            Text = "Enable Two-Factor";
+            Width = 320;
+            Height = 480;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+
+            PictureBox pb = new PictureBox { Width = 280, Height = 280, Top = 20, Left = 10 };
+            var otpUri = $"otpauth://totp/Cryptig?secret={secret}&issuer=Cryptig";
+            using (var gen = new QRCodeGenerator())
+            using (var data = gen.CreateQrCode(otpUri, QRCodeGenerator.ECCLevel.Q))
+            using (var code = new QRCode(data))
+            {
+                pb.Image = code.GetGraphic(5);
+            }
+            pb.SizeMode = PictureBoxSizeMode.StretchImage;
+
+            Label lblSecret = new Label { Text = secret, Top = pb.Bottom + 10, Left = 20, Width = 260 };
+            Label lblPrompt = new Label { Text = "Enter code from your app", Top = lblSecret.Bottom + 10, Left = 20, Width = 260 };
+            _txtCode = new TextBox { Top = lblPrompt.Bottom + 2, Left = 20, Width = 260 };
+            Button btnConfirm = new Button { Text = "Confirm", Top = _txtCode.Bottom + 10, Left = 20, Width = 260 };
+            btnConfirm.Click += BtnConfirm_Click;
+
+            Controls.AddRange(new Control[] { pb, lblSecret, lblPrompt, _txtCode, btnConfirm });
+            AcceptButton = btnConfirm;
+        }
+
+        private void BtnConfirm_Click(object? sender, EventArgs e)
+        {
+            if (TwoFactorAuth.VerifyCode(_secret, _txtCode.Text.Trim()))
+            {
+                Confirmed = true;
+                DialogResult = DialogResult.OK;
+                Close();
+            }
+            else
+            {
+                MessageBox.Show("Invalid code. Please try again.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TOTP utilities in Cryptig.Core
- store 2FA secret in `VaultData`
- add forms for verifying and enrolling 2FA
- prompt for code at login when enabled
- allow enabling/disabling 2FA from the main window
- include QRCoder and Otp.NET packages

## Testing
- `dotnet build Cryptig.Core/Cryptig.Core.csproj -v minimal`
- `dotnet build Cryptig/Cryptig.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684075ae6a90832fa8b6f66e7967e3fe